### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
     tags: [ "v*" ]
   pull_request: {}
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/becomer00t/leo-status/security/code-scanning/1](https://github.com/becomer00t/leo-status/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/rust.yml` so all jobs default to least privilege, and keep the existing `release` job override for write access.

Best fix (without changing functionality):
- Insert at workflow root (after `on:` block is a clear location):
  - `permissions:`
  - `contents: read`
- Keep existing `release` job `permissions: contents: write` unchanged, since creating a GitHub release requires write access.
- No imports, methods, or dependencies are needed (YAML config-only change).

This makes `build` explicitly read-only while preserving release behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
